### PR TITLE
contentful導入 | newsをheadlessCMS化した

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Launch Program",
+      "skipFiles": ["<node_internals>/**"],
+      "port": 9229
+    }
+  ]
+}

--- a/document/service/ Type.md
+++ b/document/service/ Type.md
@@ -23,3 +23,21 @@
 - height
 - weight
 - species: string
+
+## News
+Contentfulから抜き出すデータ。
+
+### SummaryNews
+
+- id: number
+- title: string
+- pokemon: string
+- published: Date
+
+### News
+
+- id: number
+- title: string
+- pokemon: string
+- comment: string
+- published: Date

--- a/document/service/ Type.md
+++ b/document/service/ Type.md
@@ -7,16 +7,16 @@
 ## Pokemon
 決めながらやって、随時決まったらちょっと更新する。
 
-### BookPokemon
+### SummaryBookPokemon
 
 - id: number
 - name: string
 - image: string
 - type: Type[]
 
-### DetailBookPokemon
+### BookPokemon
 
-- BookPokemon &&
+- SummaryBookPokemon &&
 - abilities: object[]
   - name: string
   - description: string

--- a/document/service/API.md
+++ b/document/service/API.md
@@ -19,4 +19,27 @@
       }
       - response: {
         pokemon: BookDetailPokemon
+        next: BookPokemon
+        prev: BookPokemon
+      }
+
+## ニュース情報の一覧取得
+- news/
+  - GET : 最新ニュース一覧の取得
+    - request: {
+      count: number
+    }
+    - response: {
+      news: SummaryNews[]
+      isNext: boolean
+    }
+  - :id
+    - GET : 詳細の取得
+      - request: {
+        id: number
+      }
+      - response: {
+        pokemon: News
+        next: SummaryNews
+        prev: SummaryNews     
       }

--- a/document/service/API.md
+++ b/document/service/API.md
@@ -8,11 +8,12 @@
       count: number
     }
     - response: {
-      BookPokemon[]
+      pokemons: BookPokemon[]
+      isNext: boolean
     }
 
-  - id
-    GET : 詳細の取得
+  - :id
+    - GET : 詳細の取得
       - request: {
         id: number
       }

--- a/document/service/API.md
+++ b/document/service/API.md
@@ -8,7 +8,7 @@
       count: number
     }
     - response: {
-      pokemons: BookPokemon[]
+      pokemons: SummaryBookPokemon[]
       isNext: boolean
     }
 
@@ -18,9 +18,9 @@
         id: number
       }
       - response: {
-        pokemon: BookDetailPokemon
-        next: BookPokemon
-        prev: BookPokemon
+        pokemon: BookPokemon
+        next: SummaryBookPokemon
+        prev: SummaryBookPokemon
       }
 
 ## ニュース情報の一覧取得

--- a/service/lib/contentful/client.ts
+++ b/service/lib/contentful/client.ts
@@ -1,0 +1,9 @@
+import * as contentful from 'contentful'
+
+const client = contentful.createClient({
+  space: '4kibrjoki4td',
+  environment: 'master',
+  accessToken: 'GyHYFhPpLJWDSASLqMLDslOPmJ-cR4G5XQTT6ac8VRA'
+});
+
+export default client;

--- a/service/lib/contentful/client.ts
+++ b/service/lib/contentful/client.ts
@@ -1,9 +1,9 @@
 import * as contentful from 'contentful'
 
 const client = contentful.createClient({
-  space: '4kibrjoki4td',
-  environment: 'master',
-  accessToken: 'GyHYFhPpLJWDSASLqMLDslOPmJ-cR4G5XQTT6ac8VRA'
+  space: process.env.NEXT_PUBLIC_CONTENTFUL_SPACE,
+  environment: process.env.NEXT_PUBLIC_CONTENTFUL_ENV,
+  accessToken: process.env.NEXT_PUBLIC_CONTENTFUL_TOKEN
 });
 
 export default client;

--- a/service/lib/contentful/getSummaryNews.ts
+++ b/service/lib/contentful/getSummaryNews.ts
@@ -1,0 +1,22 @@
+import { Entry } from "contentful";
+import { SummaryNews } from "../../types/news/SummaryNews";
+
+const getSummaryNews = (assets: Entry<any>[]): SummaryNews[] => {
+  const news: SummaryNews[] = [];
+
+  for (let i = 0; i < assets.length; i++) {
+    const field = assets[i].fields;
+    news.push({
+      id: field.id,
+      title: field.title,
+      pokemon: {
+        image: field.pokemon.fields.file.url,
+        title: field.pokemon.fields.description,
+      },
+      published: field.published
+    })
+  }
+
+  return news;
+}
+export default getSummaryNews;

--- a/service/lib/pokemon/getSummaryBookPokemon.ts
+++ b/service/lib/pokemon/getSummaryBookPokemon.ts
@@ -1,4 +1,4 @@
-import { BookPokemon } from "../../types/pokemon/BookPokemon";
+import { SummaryBookPokemon } from "../../types/pokemon/SummaryBookPokemon";
 import getPokemonImage from "./getPokemonImage";
 import getPokemonName from "./getPokemonName";
 import getPokemonType from "./getPokemonType";
@@ -6,9 +6,9 @@ import getPokemonType from "./getPokemonType";
 /**
  * 日本語のポケモン名を取得
  * @param {string} id 
- * @returns {BookPokemon} pokemon
+ * @returns {SummaryBookPokemon} pokemon
  */
-const getBookPokemon = async (id: string): Promise<BookPokemon> => {
+const getSummaryBookPokemon = async (id: string): Promise<SummaryBookPokemon> => {
 
   const name = await getPokemonName(id);
   const image = await getPokemonImage(id);
@@ -21,4 +21,4 @@ const getBookPokemon = async (id: string): Promise<BookPokemon> => {
     types
   });
 }
-export default getBookPokemon;
+export default getSummaryBookPokemon;

--- a/service/package-lock.json
+++ b/service/package-lock.json
@@ -273,6 +273,14 @@
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
       "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA=="
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
@@ -534,6 +542,35 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+    },
+    "contentful": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-8.4.2.tgz",
+      "integrity": "sha512-ddbJaJEQm58XBNjzne/lLkapEW9bWX0K3vVF16UEYyekiv2CAIaO5OwWgDD9w+VJe2wliPcDPmbtVeB9BIc/zA==",
+      "requires": {
+        "axios": "^0.21.1",
+        "contentful-resolve-response": "^1.3.0",
+        "contentful-sdk-core": "^6.5.0",
+        "fast-copy": "^2.1.0",
+        "json-stringify-safe": "^5.0.1"
+      }
+    },
+    "contentful-resolve-response": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.3.0.tgz",
+      "integrity": "sha512-FFa4it5VXW1YGyim5rhPbnwmN4c8OcmkpLrsylTL2Y1YpoC+6qnZSSU/QZyvHomLdEgwXaSXhGVJkWjpdz5IMg==",
+      "requires": {
+        "fast-copy": "^2.1.0"
+      }
+    },
+    "contentful-sdk-core": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.8.0.tgz",
+      "integrity": "sha512-X45uNrcbQ2qY2p4G/Wx2EFUdnLnoDXjw29i+d0JVTUXqCG58p3q4GHuAPzTX+uafJL4h0ZY2xPOn4nvJ83eRBQ==",
+      "requires": {
+        "fast-copy": "^2.1.0",
+        "qs": "^6.9.4"
+      }
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -832,6 +869,11 @@
         "is-extendable": "^0.1.0"
       }
     },
+    "fast-copy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.1.tgz",
+      "integrity": "sha512-Qod3DdRgFZ8GUIM6ygeoZYpQ0QLW9cf/FS9KhhjlYggcSZXWAemAw8BOCO5LuYCrR3Uj3qXDVTUzOUwG8C7beQ=="
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -858,6 +900,11 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
     },
     "foreach": {
       "version": "2.0.5",
@@ -1251,6 +1298,11 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "1.0.1",
@@ -1915,6 +1967,14 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "qs": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
+    },
     "querystring": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
@@ -2122,6 +2182,16 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
     },
     "source-map": {
       "version": "0.8.0-beta.0",

--- a/service/package.json
+++ b/service/package.json
@@ -4,10 +4,12 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "debug": "NODE_OPTIONS='--inspect' next dev",
     "build": "next build",
     "start": "next start"
   },
   "dependencies": {
+    "contentful": "^8.4.2",
     "date-fns": "^2.11.1",
     "gray-matter": "^4.0.2",
     "next": "^10.0.0",

--- a/service/pages/api/bookpokemon.ts
+++ b/service/pages/api/bookpokemon.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import getBookPokemon from '../../lib/pokemon/getBookPokemon';
+import getSummaryBookPokemon from '../../lib/pokemon/getSummaryBookPokemon';
 import { POKEMON_URL } from '../../lib/pokemon/url';
-import { BookPokemon } from '../../types/pokemon/BookPokemon';
+import { SummaryBookPokemon } from '../../types/pokemon/SummaryBookPokemon';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const limit = req.query.limit ?? 20;
@@ -20,10 +20,10 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     })
   ;
   
-  const pokemons: BookPokemon[] = [];
+  const pokemons: SummaryBookPokemon[] = [];
 
   for (let i = 0; i < pokemonIds.length; i++) {
-    const pokemon: BookPokemon = await getBookPokemon(pokemonIds[i]);
+    const pokemon: SummaryBookPokemon = await getSummaryBookPokemon(pokemonIds[i]);
     pokemons.push(pokemon);
   }
 

--- a/service/pages/api/bookpokemon/index.ts
+++ b/service/pages/api/bookpokemon/index.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
-import getSummaryBookPokemon from '../../lib/pokemon/getSummaryBookPokemon';
-import { POKEMON_URL } from '../../lib/pokemon/url';
-import { SummaryBookPokemon } from '../../types/pokemon/SummaryBookPokemon';
+import getSummaryBookPokemon from '../../../lib/pokemon/getSummaryBookPokemon';
+import { POKEMON_URL } from '../../../lib/pokemon/url';
+import { SummaryBookPokemon } from '../../../types/pokemon/SummaryBookPokemon';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const limit = req.query.limit ?? 20;

--- a/service/pages/api/news/index.ts
+++ b/service/pages/api/news/index.ts
@@ -1,0 +1,23 @@
+import { Entry } from "contentful";
+import { NextApiRequest, NextApiResponse } from "next";
+import { SummaryNews } from "../../../types/news/SummaryNews";
+
+import client from '../../../lib/contentful/client';
+import getSummaryNews from "../../../lib/contentful/getSummaryNews";
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  
+  const results: Entry<any>[] = await client.getEntries({
+    content_type: 'blogPost'
+  })
+    .then(res => res.items)
+  ;
+  
+  if (!results) {
+    res.status(404).json({ message: '記事は見つかりませんでした' });
+  }
+
+  const news: SummaryNews[] = getSummaryNews(results);
+
+  res.status(200).json(news);
+}

--- a/service/pages/api/news/index.ts
+++ b/service/pages/api/news/index.ts
@@ -6,11 +6,23 @@ import client from '../../../lib/contentful/client';
 import getSummaryNews from "../../../lib/contentful/getSummaryNews";
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
+
+  const MAX_ENTRIES = 20;
+
+  const limit = req.query.limit ?? MAX_ENTRIES;
+  const offset = req.query.offset ?? 0;
+  
+  let isNext: boolean = true;
   
   const results: Entry<any>[] = await client.getEntries({
-    content_type: 'blogPost'
+    content_type: 'blogPost',
+    limit,
+    skip: offset
   })
-    .then(res => res.items)
+    .then(res => {
+      isNext = res.total === limit ? true : false;
+      return res.items;
+    })
   ;
   
   if (!results) {
@@ -19,5 +31,8 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
   const news: SummaryNews[] = getSummaryNews(results);
 
-  res.status(200).json(news);
+  res.status(200).json({
+    news,
+    isNext
+  });
 }

--- a/service/pages/index.tsx
+++ b/service/pages/index.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link'
-import { GetStaticProps, InferGetStaticPropsType } from 'next'
+import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
 import { SummaryBookPokemon } from '../types/pokemon/SummaryBookPokemon'
 import { useState } from 'react'
 
-export default function Home({ initialPokemons, isNext }: InferGetStaticPropsType<typeof getStaticProps>) {
+export default function Home({ initialPokemons, isNext }: InferGetServerSidePropsType<typeof getServerSideProps>) {
 
   const [pager, setPager] = useState<number>(1);
   const [next, setNext] = useState<boolean>(isNext);
@@ -30,7 +30,7 @@ export default function Home({ initialPokemons, isNext }: InferGetStaticPropsTyp
   )  
 }
 
-export const getStaticProps: GetStaticProps = async () => {
+export const getServerSideProps: GetServerSideProps = async () => {
 
   const { result, isNext } = await fetch (`${process.env.NEXT_PUBLIC_API}bookpokemon`).then(res => res.json());
   return {

--- a/service/pages/index.tsx
+++ b/service/pages/index.tsx
@@ -11,7 +11,7 @@ export default function Home({ initialPokemons, isNext }: InferGetServerSideProp
 
   const more = async () => {
     setPager(pager + 1);
-    const { result, isNext } = await fetch (`${process.env.NEXT_PUBLIC_VERCEL_URL}/api/bookpokemon/?offset=${pager * 20}&limit=20`).then(res => res.json());
+    const { result, isNext } = await fetch (`${process.env.NEXT_PUBLIC_PROTOCOL}${process.env.NEXT_PUBLIC_VERCEL_URL}/api/bookpokemon/?offset=${pager * 20}&limit=20`).then(res => res.json());
     setPokemons(pokemons.concat(result));
     setNext(isNext);
   }
@@ -32,7 +32,7 @@ export default function Home({ initialPokemons, isNext }: InferGetServerSideProp
 
 export const getServerSideProps: GetServerSideProps = async () => {
 
-  const { result, isNext } = await fetch (`${process.env.NEXT_PUBLIC_VERCEL_URL}/api/bookpokemon`).then(res => res.json());
+  const { result, isNext } = await fetch (`${process.env.NEXT_PUBLIC_PROTOCOL}${process.env.NEXT_PUBLIC_VERCEL_URL}/api/bookpokemon`).then(res => res.json());
   return {
     props: {
       initialPokemons: result,

--- a/service/pages/index.tsx
+++ b/service/pages/index.tsx
@@ -11,7 +11,7 @@ export default function Home({ initialPokemons, isNext }: InferGetServerSideProp
 
   const more = async () => {
     setPager(pager + 1);
-    const { result, isNext } = await fetch (`${process.env.NEXT_PUBLIC_API_URL}/api/bookpokemon/?offset=${pager * 20}&limit=20`).then(res => res.json());
+    const { result, isNext } = await fetch (`${process.env.NEXT_PUBLIC_VERCEL_URL}/api/bookpokemon/?offset=${pager * 20}&limit=20`).then(res => res.json());
     setPokemons(pokemons.concat(result));
     setNext(isNext);
   }
@@ -32,7 +32,7 @@ export default function Home({ initialPokemons, isNext }: InferGetServerSideProp
 
 export const getServerSideProps: GetServerSideProps = async () => {
 
-  const { result, isNext } = await fetch (`${process.env.NEXT_PUBLIC_API_URL}/api/bookpokemon`).then(res => res.json());
+  const { result, isNext } = await fetch (`${process.env.NEXT_PUBLIC_VERCEL_URL}/api/bookpokemon`).then(res => res.json());
   return {
     props: {
       initialPokemons: result,

--- a/service/pages/index.tsx
+++ b/service/pages/index.tsx
@@ -11,7 +11,7 @@ export default function Home({ initialPokemons, isNext }: InferGetServerSideProp
 
   const more = async () => {
     setPager(pager + 1);
-    const { result, isNext } = await fetch (`${process.env.NEXT_PUBLIC_API}bookpokemon/?offset=${pager * 20}&limit=20`).then(res => res.json());
+    const { result, isNext } = await fetch (`${process.env.NEXT_PUBLIC_API_URL}/api/bookpokemon/?offset=${pager * 20}&limit=20`).then(res => res.json());
     setPokemons(pokemons.concat(result));
     setNext(isNext);
   }
@@ -32,7 +32,7 @@ export default function Home({ initialPokemons, isNext }: InferGetServerSideProp
 
 export const getServerSideProps: GetServerSideProps = async () => {
 
-  const { result, isNext } = await fetch (`${process.env.NEXT_PUBLIC_API}bookpokemon`).then(res => res.json());
+  const { result, isNext } = await fetch (`${process.env.NEXT_PUBLIC_API_URL}/api/bookpokemon`).then(res => res.json());
   return {
     props: {
       initialPokemons: result,

--- a/service/pages/index.tsx
+++ b/service/pages/index.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link'
-import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
+import { GetStaticProps, InferGetStaticPropsType } from 'next'
 import { SummaryBookPokemon } from '../types/pokemon/SummaryBookPokemon'
 import { useState } from 'react'
 
-export default function Home({ initialPokemons, isNext }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+export default function Home({ initialPokemons, isNext }: InferGetStaticPropsType<typeof getStaticProps>) {
 
   const [pager, setPager] = useState<number>(1);
   const [next, setNext] = useState<boolean>(isNext);
@@ -30,7 +30,7 @@ export default function Home({ initialPokemons, isNext }: InferGetServerSideProp
   )  
 }
 
-export const getServerSideProps: GetServerSideProps = async () => {
+export const getStaticProps: GetStaticProps = async () => {
 
   const { result, isNext } = await fetch (`${process.env.NEXT_PUBLIC_API}bookpokemon`).then(res => res.json());
   return {

--- a/service/pages/index.tsx
+++ b/service/pages/index.tsx
@@ -1,13 +1,13 @@
 import Link from 'next/link'
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
-import { BookPokemon } from '../types/pokemon/BookPokemon'
+import { SummaryBookPokemon } from '../types/pokemon/SummaryBookPokemon'
 import { useState } from 'react'
 
 export default function Home({ initialPokemons, isNext }: InferGetServerSidePropsType<typeof getServerSideProps>) {
 
   const [pager, setPager] = useState<number>(1);
   const [next, setNext] = useState<boolean>(isNext);
-  const [pokemons, setPokemons] = useState<BookPokemon[]>(initialPokemons);
+  const [pokemons, setPokemons] = useState<SummaryBookPokemon[]>(initialPokemons);
 
   const more = async () => {
     setPager(pager + 1);

--- a/service/pages/news/index.tsx
+++ b/service/pages/news/index.tsx
@@ -27,7 +27,7 @@ export default function News({ news, isNext }: InferGetServerSidePropsType<typeo
 
 export const getServerSideProps: GetServerSideProps = async () => {
 
-  const { news, isNext } = await fetch (`${process.env.NEXT_PUBLIC_API_URL}/api/news`).then(res => res.json());
+  const { news, isNext } = await fetch (`${process.env.NEXT_PUBLIC_VERCEL_URL}/api/news`).then(res => res.json());
   return {
     props: {
       news,

--- a/service/pages/news/index.tsx
+++ b/service/pages/news/index.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+import { GetStaticProps, InferGetStaticPropsType } from 'next'
+import { useState } from 'react'
+
+export default function News({ news, isNext }: InferGetStaticPropsType<typeof getStaticProps>) {
+
+  const [pager,] = useState<number>(1);
+  const [next,] = useState<boolean>(isNext);
+  const [prev,] = useState<boolean>(false);
+
+  return (
+    <section>
+      <h1>更新情報</h1>
+      <ul>
+        {news.map(content => {
+          return (<li key={content.id}>{content.published} : {content.title} ( {content.pokemon.title} ) - {content.pokemon.image}</li>)
+        })}
+      </ul>
+      <div className="pager">
+        { prev ? <Link href={`/news/${pager - 1}`}>{pager - 1}</Link> : ''}
+        <span>{pager}</span>
+        { next ? <Link href={`/news/${pager + 1}`}>{pager + 1}</Link> : ''}
+      </div>
+    </section>
+  )  
+}
+
+export const getStaticProps: GetStaticProps = async () => {
+
+  const { news, isNext } = await fetch (`${process.env.NEXT_PUBLIC_API}news`).then(res => res.json());
+  return {
+    props: {
+      news,
+      isNext
+    }
+  };
+}

--- a/service/pages/news/index.tsx
+++ b/service/pages/news/index.tsx
@@ -27,7 +27,7 @@ export default function News({ news, isNext }: InferGetServerSidePropsType<typeo
 
 export const getServerSideProps: GetServerSideProps = async () => {
 
-  const { news, isNext } = await fetch (`${process.env.NEXT_PUBLIC_API}news`).then(res => res.json());
+  const { news, isNext } = await fetch (`${process.env.NEXT_PUBLIC_API_URL}/api/news`).then(res => res.json());
   return {
     props: {
       news,

--- a/service/pages/news/index.tsx
+++ b/service/pages/news/index.tsx
@@ -27,7 +27,7 @@ export default function News({ news, isNext }: InferGetServerSidePropsType<typeo
 
 export const getServerSideProps: GetServerSideProps = async () => {
 
-  const { news, isNext } = await fetch (`${process.env.NEXT_PUBLIC_VERCEL_URL}/api/news`).then(res => res.json());
+  const { news, isNext } = await fetch (`${process.env.NEXT_PUBLIC_PROTOCOL}${process.env.NEXT_PUBLIC_VERCEL_URL}/api/news`).then(res => res.json());
   return {
     props: {
       news,

--- a/service/pages/news/index.tsx
+++ b/service/pages/news/index.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link'
-import { GetStaticProps, InferGetStaticPropsType } from 'next'
+import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
 import { useState } from 'react'
 
-export default function News({ news, isNext }: InferGetStaticPropsType<typeof getStaticProps>) {
+export default function News({ news, isNext }: InferGetServerSidePropsType<typeof getServerSideProps>) {
 
   const [pager,] = useState<number>(1);
   const [next,] = useState<boolean>(isNext);
@@ -25,7 +25,7 @@ export default function News({ news, isNext }: InferGetStaticPropsType<typeof ge
   )  
 }
 
-export const getStaticProps: GetStaticProps = async () => {
+export const getServerSideProps: GetServerSideProps = async () => {
 
   const { news, isNext } = await fetch (`${process.env.NEXT_PUBLIC_API}news`).then(res => res.json());
   return {

--- a/service/types/news/SummaryNews.ts
+++ b/service/types/news/SummaryNews.ts
@@ -1,0 +1,9 @@
+export type SummaryNews = {
+  id: string;
+  title: string;
+  pokemon: {
+    image: string;
+    title: string;
+  };
+  published: Date;
+}

--- a/service/types/pokemon/SummaryBookPokemon.ts
+++ b/service/types/pokemon/SummaryBookPokemon.ts
@@ -1,6 +1,6 @@
 import { Type } from './Type';
 
-export type BookPokemon = {
+export type SummaryBookPokemon = {
   id: string;
   name: string;
   image: string;


### PR DESCRIPTION
## issue
- fix: #10 

## やったこと
- contentfulのスペースを追加
- contentfulのクライアントを追加してリクエストでfetchできる状態にした
- news近辺のAPI / TypeScript型定義を行なった
- 型定義に沿ってSummaryNewsを定義
- API定義に沿ってAPIを追加
- 簡単なViewを追加

### ついでにやったこと
- bookpokemonのAPI定義が古かったので修正した
- bookPokemonのAPIのディレクトリ階層を修正
- bookpokemonのAPIをSSGにした（ポケモンAPIが頻繁に変わることはあまり考えられないため）