### PR TITLE
ゲットしたポケモンが正常に表示されない不具合を解消

### DIFF
--- a/service/components/bookpokemon/AllBookContents.tsx
+++ b/service/components/bookpokemon/AllBookContents.tsx
@@ -1,0 +1,113 @@
+
+import styled from 'styled-components';
+import { SummaryBookPokemon } from '../../types/pokemon/SummaryBookPokemon';
+import Panel from './Panel';
+
+type Props = {
+  pokemons: SummaryBookPokemon[];
+  pager: number;
+  next: boolean;
+  viewMore: () => void;
+}
+
+const AllBookContents: React.FC<Props> = ({ pokemons, pager, next, viewMore }) => {
+
+  return (
+    <Section>
+      <List>
+        {pokemons.map(pokemon => {
+          return (<Panel key={pokemon.id} pokemon={pokemon} />)
+        })}
+      </List>
+
+      <Pager>
+        { next ? <Button onClick={viewMore}>もっと見る</Button> : ''}
+      </Pager>
+    </Section>
+  );
+}
+
+export const Section = styled.section`
+  margin: 0 auto 80px;
+  width: 100%;
+  max-width: 800px;
+`;
+
+export const FilterLink = styled.div`
+  margin: 0 auto 80px;
+  max-width: 500px;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const FilterLnkList = styled.button<{ isActive: boolean, isLink: boolean }>`
+  border: none;
+  background-color: transparent;
+  line-height: 2;
+  font-size: 16px;
+  cursor: pointer;
+  ${({ isLink }) => {
+    if (isLink) return;
+    return `
+      text-decoration: line-through;
+      pointer-events: none;
+    `;
+  }}
+  ${({ isActive }) => {
+    if (!isActive) return;
+    return `
+      position: relative;
+      &:after {
+        content: '';
+        position: absolute;
+        bottom: -10px;
+        left: 50%;
+        transform: translateX(-50%);
+        background-color: #000;
+        width: 20px;
+        height: 2px;
+    `;
+  }}
+`;
+
+export const List = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 60px;
+  &:after {
+    content: '';
+    display: block;
+    width: calc(25% - 10px);
+  }
+`;
+
+export const Pager = styled.div`
+  text-align: center;
+`;
+export const Button = styled.button`
+  color: #fff;
+  background-color: #E6001A;
+  width: 300px;
+  padding: 12px 12px 14px;
+  border: none;
+  font-size: 18px;
+  position: relative;
+  cursor: pointer;
+  &::after {
+    content: '';
+    position: absolute;
+    width: 6px;
+    height: 6px;
+    border-right: 2px solid #fff;
+    border-bottom: 2px solid #fff;
+    transform: rotate(-45deg) translateY(-50%);
+    right: 16px;
+    top: 50%;
+  }
+`;
+
+export default AllBookContents;

--- a/service/components/bookpokemon/BookContents.tsx
+++ b/service/components/bookpokemon/BookContents.tsx
@@ -88,10 +88,6 @@ const BookContents: React.FC<Props> = ({ pokemons, pager, next, viewMore }) => {
 
       {queryComponent()}
 
-      <Pager>
-        { next ? <Button onClick={viewMore}>もっと見る</Button> : ''}
-      </Pager>
-
     </Section>
   );
 }

--- a/service/components/bookpokemon/BookContents.tsx
+++ b/service/components/bookpokemon/BookContents.tsx
@@ -15,11 +15,10 @@ type Props = {
   pokemons: SummaryBookPokemon[];
   pager: number;
   next: boolean;
-  isUseUnknown: boolean;
   viewMore: () => void;
 }
 
-const Contents: React.FC<Props> = ({ pokemons, pager, next, viewMore, isUseUnknown }) => {
+const BookContents: React.FC<Props> = ({ pokemons, pager, next, viewMore }) => {
 
   const statuses = useSelector((state: RootState) => state.pokemon);
   const router = useRouter();
@@ -36,17 +35,12 @@ const Contents: React.FC<Props> = ({ pokemons, pager, next, viewMore, isUseUnkno
     });
   }
 
-  const mainComponent = () => {
+  const queryComponent = () => {
     if (book === 'get') {
       return (
         <List>
-          {pokemons.map(pokemon => {
-            const isEncounter = statuses.encounter.find(status => status === Number(pokemon.id));
-            const isGet = statuses.get.find(status => status === Number(pokemon.id));
-            if (isEncounter || isGet) {
-              return (<Panel key={pokemon.id} pokemon={pokemon} />)
-            }
-          })}
+          
+          <p>いないよ</p>
         </List>
       );
     } else {
@@ -56,7 +50,7 @@ const Contents: React.FC<Props> = ({ pokemons, pager, next, viewMore, isUseUnkno
             {pokemons.map(pokemon => {
               const isEncounter = statuses.encounter.find(status => status === Number(pokemon.id));
               const isGet = statuses.get.find(status => status === Number(pokemon.id));
-              if (isEncounter || isGet || isUseUnknown) {
+              if (isEncounter || isGet) {
                 return (<Panel key={pokemon.id} pokemon={pokemon} />)
               }
               return (<UnknownPanel key={pokemon.id} id={pokemon.id} />)
@@ -71,21 +65,21 @@ const Contents: React.FC<Props> = ({ pokemons, pager, next, viewMore, isUseUnkno
     }
   }
 
-  const filterLinkComponent = () => {
-    if (isUseUnknown) return;
-    return (
+  return (
+    <Section>
+
       <FilterLink>
         <FilterLnkList isLink isActive={isAllActive} onClick={() => moveTo('all')}>すべての<br />ずかん</FilterLnkList>
         <FilterLnkList isLink isActive={isGetActive} onClick={() => moveTo('get')}>つかまえた<br />ポケモン</FilterLnkList>
         <FilterLnkList isLink={false} isActive={isEncounterActive} onClick={() => moveTo('encounter')}>みつけた<br />ポケモン</FilterLnkList>
       </FilterLink>
-    );
-  }
 
-  return (
-    <Section>
-      {filterLinkComponent()}
-      {mainComponent()}
+      {queryComponent()}
+
+      <Pager>
+        { next ? <Button onClick={viewMore}>もっと見る</Button> : ''}
+      </Pager>
+
     </Section>
   );
 }
@@ -173,4 +167,4 @@ export const Button = styled.button`
   }
 `;
 
-export default Contents;
+export default BookContents;

--- a/service/components/bookpokemon/BookContents.tsx
+++ b/service/components/bookpokemon/BookContents.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 const BookContents: React.FC<Props> = ({ pokemons, pager, next, viewMore }) => {
 
-  const statuses = useSelector((state: RootState) => state.pokemon);
+  const myBook = useSelector((state: RootState) => state.pokemon);
   const router = useRouter();
   const { book } = router.query;
 
@@ -48,8 +48,8 @@ const BookContents: React.FC<Props> = ({ pokemons, pager, next, viewMore }) => {
         <>
           <List>
             {pokemons.map(pokemon => {
-              const isEncounter = statuses.encounter.find(status => status === Number(pokemon.id));
-              const isGet = statuses.get.find(status => status === Number(pokemon.id));
+              const isEncounter = myBook.encounter.find(status => status === Number(pokemon.id));
+              const isGet = myBook.get.find(status => status === Number(pokemon.id));
               if (isEncounter || isGet) {
                 return (<Panel key={pokemon.id} pokemon={pokemon} />)
               }

--- a/service/components/bookpokemon/BookContents.tsx
+++ b/service/components/bookpokemon/BookContents.tsx
@@ -1,10 +1,12 @@
 
 import { useSelector } from 'react-redux';
 import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { RootState } from '../../store';
 import { SummaryBookPokemon } from '../../types/pokemon/SummaryBookPokemon';
+import formatSummaryBookPokemon from '../../lib/pokemon/formatSummaryBookPokemon';
 
 import Panel from './Panel';
 import UnknownPanel from './UnknownPanel';
@@ -20,9 +22,16 @@ type Props = {
 
 const BookContents: React.FC<Props> = ({ pokemons, pager, next, viewMore }) => {
 
-  const myBook = useSelector((state: RootState) => state.pokemon);
+  const myBookIds = useSelector((state: RootState) => state.pokemon);
   const router = useRouter();
+  const [myBookPokemon, setMyBookPokemon] = useState<SummaryBookPokemon[]>([]);
   const { book } = router.query;
+
+  useEffect(() => {
+    Promise.all(myBookIds.get.map(async id => {
+      return await formatSummaryBookPokemon(id.toString());
+    })).then(pokemons => setMyBookPokemon(pokemons));
+  }, []);
 
   const isAllActive = (book === 'all' || !book);
   const isGetActive = book === 'get';
@@ -39,8 +48,11 @@ const BookContents: React.FC<Props> = ({ pokemons, pager, next, viewMore }) => {
     if (book === 'get') {
       return (
         <List>
-          
-          <p>いないよ</p>
+          {myBookPokemon.length === 0
+            ? <p>まだいないよ</p>
+            : myBookPokemon.map( (pokemon) => {
+                return (<Panel key={pokemon.id} pokemon={pokemon} />);
+          })}
         </List>
       );
     } else {
@@ -48,8 +60,8 @@ const BookContents: React.FC<Props> = ({ pokemons, pager, next, viewMore }) => {
         <>
           <List>
             {pokemons.map(pokemon => {
-              const isEncounter = myBook.encounter.find(status => status === Number(pokemon.id));
-              const isGet = myBook.get.find(status => status === Number(pokemon.id));
+              const isEncounter = myBookIds.encounter.find(status => status === Number(pokemon.id));
+              const isGet = myBookIds.get.find(status => status === Number(pokemon.id));
               if (isEncounter || isGet) {
                 return (<Panel key={pokemon.id} pokemon={pokemon} />)
               }

--- a/service/pages/all.tsx
+++ b/service/pages/all.tsx
@@ -4,7 +4,7 @@ import { SummaryBookPokemon } from '../types/pokemon/SummaryBookPokemon'
 
 import Header from '../components/common/Header';
 import PageTitle from '../components/common/PageTitle';
-import BookPokemonContents from '../components/bookpokemon/Contents';
+import BookPokemonContents from '../components/bookpokemon/AllBookContents';
 import Footer from '../components/common/Footer';
 import getSummaryBookPokemonList from '../lib/pokemon/getSummaryBookPokemonList';
 
@@ -30,7 +30,6 @@ export default function All({ initialPokemons, isNext }: InferGetStaticPropsType
         pokemons={pokemons}
         pager={pager}
         viewMore={more}
-        isUseUnknown
       />
       <Footer />
     </>

--- a/service/pages/bookpokemon/index.tsx
+++ b/service/pages/bookpokemon/index.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 
 import Header from '../../components/common/Header';
 import PageTitle from '../../components/common/PageTitle';
-import BookPokemonContents from '../../components/bookpokemon/Contents';
+import BookPokemonContents from '../../components/bookpokemon/BookContents';
 import Footer from '../../components/common/Footer';
 
 import getSummaryBookPokemonList from '../../lib/pokemon/getSummaryBookPokemonList';
@@ -26,7 +26,7 @@ export default function All({ initialPokemons, isNext }: InferGetStaticPropsType
     <>
       <Header />
       <PageTitle title='ポケモン図鑑そうごう' menu='book' />
-      <BookPokemonContents next={next} pokemons={pokemons} pager={pager} viewMore={more} isUseUnknown={false}  />
+      <BookPokemonContents next={next} pokemons={pokemons} pager={pager} viewMore={more} />
       <Footer />
     </>
   )  

--- a/service/pages/search/[slug].tsx
+++ b/service/pages/search/[slug].tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useDispatch } from 'react-redux';
 
-import { incrementPokemon } from '../../store/pokemonSlice';
+import { updateMyBook } from '../../store/myBookSlice';
 
 import Header from '../../components/common/Header';
 import PageTitle from '../../components/common/PageTitle';
@@ -55,7 +55,7 @@ export default function SearchPage() {
   useEffect(() => {
     if (!pokemon) return;
 
-    dispatch(incrementPokemon({
+    dispatch(updateMyBook({
       status: 'get',
       id: pokemon.id
     }))

--- a/service/store/index.ts
+++ b/service/store/index.ts
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit'
-import pokemonReducer from './pokemonSlice'
+import pokemonReducer from './myBookSlice'
 
 export const store = configureStore({
   reducer: {

--- a/service/store/myBookSlice.ts
+++ b/service/store/myBookSlice.ts
@@ -1,11 +1,15 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-export type BookPokemonState = {
+/**
+ * みつけたポケモン・ゲットしたポケモンの状態を管理する
+ */
+
+export type TMyBook = {
   get: number[]
   encounter: number[]
 };
 
-export const initialState: BookPokemonState = {
+export const initialState: TMyBook = {
   get: [],
   encounter: []
 };
@@ -14,11 +18,11 @@ type TAction = {
   status: 'get' | 'encounter',
   id: number
 }
-export const bookPokemonSlice = createSlice({
-  name: 'bookPokemon',
+export const myBookSlice = createSlice({
+  name: 'myBook',
   initialState,
   reducers: {
-    incrementPokemon: (state, action: PayloadAction<TAction>) => {
+    updateMyBook: (state, action: PayloadAction<TAction>) => {
 
       const ids = state.encounter.concat(action.payload.id);
 
@@ -37,5 +41,5 @@ export const bookPokemonSlice = createSlice({
     }
   },
 });
-export default bookPokemonSlice.reducer
-export const { incrementPokemon } = bookPokemonSlice.actions
+export default myBookSlice.reducer
+export const { updateMyBook } = myBookSlice.actions

--- a/service/store/myBookSlice.ts
+++ b/service/store/myBookSlice.ts
@@ -30,12 +30,12 @@ export const myBookSlice = createSlice({
         case 'encounter' :
           return {
             ...state,
-            encouner: ids
+            encouner: [...state.encounter, action.payload.id]
           }
         case 'get' :
           return {
             ...state,
-            get: ids
+            get: [...state.get, action.payload.id]
           }
       }
     }

--- a/service/store/myBookSlice.ts
+++ b/service/store/myBookSlice.ts
@@ -10,7 +10,7 @@ export type TMyBook = {
 };
 
 export const initialState: TMyBook = {
-  get: [],
+  get: [1, 4, 7],
   encounter: []
 };
 


### PR DESCRIPTION
## issue
- fix: #29 

## やったこと
- 複雑になっていた`bookContents`コンポーネントを`/all`と`/bookpokemons`で分割
- ストアのReducerの実装ミスを修正
- ゲットしたポケモンのロジックを見直して実装

https://user-images.githubusercontent.com/36039518/126058321-f6bd1576-196a-465a-b5a7-06d3b1fce0f7.mov


