### PR TITLE
ReduxへのID保存時重複チェック｜軽微なスタイル修正

### DIFF
--- a/service/components/bookpokemon/AllBookContents.tsx
+++ b/service/components/bookpokemon/AllBookContents.tsx
@@ -78,10 +78,13 @@ export const List = styled.div`
   align-items: flex-start;
   justify-content: space-between;
   margin-bottom: 60px;
-  &:after {
+  &:after, &:before {
     content: '';
     display: block;
     width: calc(25% - 10px);
+  }
+  &:before {
+    order: 1;
   }
 `;
 

--- a/service/components/bookpokemon/BookContents.tsx
+++ b/service/components/bookpokemon/BookContents.tsx
@@ -143,10 +143,13 @@ export const List = styled.div`
   align-items: flex-start;
   justify-content: space-between;
   margin-bottom: 60px;
-  &:after {
+  &:after, &:before {
     content: '';
     display: block;
     width: calc(25% - 10px);
+  }
+  &:before {
+    order: 1;
   }
 `;
 

--- a/service/pages/search/[slug].tsx
+++ b/service/pages/search/[slug].tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
+import { RootState } from '../../store';
 import { updateMyBook } from '../../store/myBookSlice';
 
 import Header from '../../components/common/Header';
@@ -13,7 +14,6 @@ import DetectPokemon from '../../components/search/DetectPokemon';
 import { SearchPlace } from '../../types/search/SearchPlace';
 import PLACES from '../../lib/database/places';
 import searchPokemon from '../../lib/pokemon/searchPokemon';
-
 
 type Pokemon = {
   name: string;
@@ -27,6 +27,8 @@ export default function SearchPage() {
   const [pokemon, setPokemon] = useState<Pokemon>(null);
 
   const dispatch = useDispatch();
+  const myBookIds = useSelector((state: RootState) => state.pokemon);
+
   const router = useRouter();
   const { slug } = router.query;
 
@@ -54,6 +56,10 @@ export default function SearchPage() {
 
   useEffect(() => {
     if (!pokemon) return;
+
+    // 重複チェック。すでにゲットしたポケモンは状態管理に追加しない
+    const isDuplicated = myBookIds.get.find(id => id === pokemon.id);
+    if (isDuplicated) return;
 
     dispatch(updateMyBook({
       status: 'get',


### PR DESCRIPTION
## issue
- fix: #34 
- fix: #28 

## やったこと
- 一度ゲットしたポケモンは再度IDを保存すると、ゲットしたポケモンのエリアが重複するため、IDが重複しないようにした。
- レイアウト崩れを発見したので修正した。
